### PR TITLE
Iu/favorites types color

### DIFF
--- a/src/views/Favorites/FavoritesAvatar.vue
+++ b/src/views/Favorites/FavoritesAvatar.vue
@@ -103,7 +103,7 @@
                                         <span class="group-item__count">{{ group.count }}/{{ group.capacity }}</span>
                                     </div>
                                     <div class="group-item__bottom">
-                                        <Badge variant="outline">
+                                        <Badge :class="avatarGroupVisibilityColors[group.visibility]" variant="outline">
                                             {{ formatVisibility(group.visibility) }}
                                         </Badge>
                                         <Popover
@@ -542,6 +542,11 @@
     const LOCAL_AVATAR_VIEWPORT_BUFFER = 32;
 
     const avatarGroupVisibilityOptions = ref(['public', 'friends', 'private']);
+    const avatarGroupVisibilityColors = {
+        public: 'text-green-500 border-green-500',
+        friends: 'text-blue-500 border-blue-500',
+        private: 'text-red-500 border-red-500'
+    };
     const historyGroupKey = 'local-history';
     const avatarSplitterSize = ref(260);
 

--- a/src/views/Favorites/FavoritesFriend.vue
+++ b/src/views/Favorites/FavoritesFriend.vue
@@ -95,7 +95,9 @@
                                     :key="group.key"
                                     :class="[
                                         'group-item',
-                                        { 'is-active': !hasSearchInput && isGroupActive('remote', group.key) }
+                                        {
+                                            'is-active': !hasSearchInput && isGroupActive('remote', group.key)
+                                        }
                                     ]"
                                     @click="handleGroupClick('remote', group.key)">
                                     <div class="group-item__top">
@@ -103,7 +105,7 @@
                                         <span class="group-item__count">{{ group.count }}/{{ group.capacity }}</span>
                                     </div>
                                     <div class="group-item__bottom">
-                                        <Badge variant="outline">
+                                        <Badge :class="friendGroupVisibilityColors[group.visibility]" variant="outline">
                                             {{ formatVisibility(group.visibility) }}
                                         </Badge>
                                         <Popover
@@ -139,7 +141,9 @@
                                                                 type="button"
                                                                 :class="[
                                                                     'group-visibility-menu__item',
-                                                                    { 'is-active': group.visibility === visibility }
+                                                                    {
+                                                                        'is-active': group.visibility === visibility
+                                                                    }
                                                                 ]"
                                                                 @click="handleVisibilitySelection(group, visibility)">
                                                                 <span>{{ formatVisibility(visibility) }}</span>
@@ -321,6 +325,11 @@
     import configRepository from '../../service/config.js';
 
     const friendGroupVisibilityOptions = ref(['public', 'friends', 'private']);
+    const friendGroupVisibilityColors = {
+        public: 'text-green-500 border-green-500',
+        friends: 'text-blue-500 border-blue-500',
+        private: 'text-red-500 border-red-500'
+    };
 
     const friendSplitterSize = ref(260);
 

--- a/src/views/Favorites/FavoritesWorld.vue
+++ b/src/views/Favorites/FavoritesWorld.vue
@@ -103,7 +103,7 @@
                                         <span class="group-item__count">{{ group.count }}/{{ group.capacity }}</span>
                                     </div>
                                     <div class="group-item__bottom">
-                                        <Badge variant="outline">
+                                        <Badge :class="worldGroupVisibilityColors[group.visibility]" variant="outline">
                                             {{ formatVisibility(group.visibility) }}
                                         </Badge>
                                         <Popover
@@ -532,6 +532,11 @@
     });
 
     const worldGroupVisibilityOptions = ref(['public', 'friends', 'private']);
+    const worldGroupVisibilityColors = {
+        public: 'text-green-500 border-green-500',
+        friends: 'text-blue-500 border-blue-500',
+        private: 'text-red-500 border-red-500'
+    };
     const worldSplitterSize = ref(260);
     const worldExportDialogVisible = ref(false);
     const worldFavoriteSearch = ref('');


### PR DESCRIPTION
This PR adds visual color to type badges on favorite views:

- Favorites visibility (public, friends, private)

## Screenshots 

**Favorite Friends tab - Before**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/11643442-1b89-4537-af7d-da542614c622" />

**Favorite Friends tab - After**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/121b2711-7995-4571-ab0e-58c3b5ecd2ca" />

**Favorite Worlds tab - Before**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/5b4bfa5e-1c7b-4d1e-a324-e883a1058bee" />

**Favorite Worlds tab - After**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/f297e85b-081a-45ac-a658-c256f0cebdea" />

**Favorite Avatars tab - Before**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/d8a6c3e7-66b4-4865-ac1d-95ca94364801" />

**Favorite Avatars tab - After**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/0fbcd9e4-64df-423f-ab76-9049c2a5ef01" />

